### PR TITLE
Change Default Wishlist State to False

### DIFF
--- a/client/src/Components/ProductCard.js
+++ b/client/src/Components/ProductCard.js
@@ -1,30 +1,45 @@
-import React from 'react'
+import React from "react";
 
-function ProductCard({prop}) {
+function ProductCard({ prop }) {
   return (
     <div class=" rounded overflow-hidden shadow-lg">
-        
-        <div className='relative top-8 left-64 '>
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 fill-current text-red-600">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
-</svg>
+      <div className="relative top-8 left-64 ">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="w-6 h-6 "
+        >
+          {/* simply add "fill-current text-red-600" to the above class to fill red color when implementing wishlist feature.*/}
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"
+          />
+        </svg>
+      </div>
+      <img
+        class="w-72 text-center "
+        src={prop.image}
+        alt="Sunset in the mountains"
+      />
+      <div class="px-6 py-4">
+        <div class="font-bold text-xl mb-2">{prop.brand}</div>
+        <p class="text-gray-700 text-base">{prop.title}</p>
+        <div className="flex  items-center">
+          <div className="font-bold text-md mb-2 ">{prop.discountprice}</div>
+          <div className=" line-through mb-2">{prop.actualprice}</div>
+          <div className="text-red-600 font-medium mb-2 ">{`( ${
+            Number.parseInt(prop.discountpercentage)
+              ? prop.discountpercentage
+              : "20"
+          }% OFF )`}</div>
         </div>
-  <img class="w-72 text-center " src={prop.image} alt="Sunset in the mountains"/>
-  <div class="px-6 py-4">
-    <div class="font-bold text-xl mb-2">{prop.brand}</div>
-    <p class="text-gray-700 text-base">
-    {prop.title}
-    </p>
-    <div className='flex  items-center'>
-        <div className='font-bold text-md mb-2 '>{prop.discountprice}</div>
-        <div className=' line-through mb-2'>{prop.actualprice}</div>
-        <div className='text-red-600 font-medium mb-2 '>{`( ${Number.parseInt(prop.discountpercentage)?prop.discountpercentage:"20"}% OFF )`}</div>
+      </div>
     </div>
-  </div>
- 
-
-</div>
-  )
+  );
 }
 
-export default ProductCard
+export default ProductCard;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "TrendTrove",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Description :

Changed the default state of the wishlist icon in Product Cards to `False` to ensure items does not appear to be wishlisted by default.

## Motivation and Context : 

- The previous implementation had items appearing as wishlisted by default. This change resolves that issue by making modifications in the SVG.

- Fixes and Closes https://github.com/Niharika0104/TrendTrove/issues/16

## Screenshots : 
- ### Before : 
<img src="https://github.com/Niharika0104/TrendTrove/assets/88451512/b92114ec-5043-459c-8d5d-3f466ac70d50" width="400">

- ### After : 
<img src="https://github.com/Niharika0104/TrendTrove/assets/88451512/70e04b9e-d83e-475d-972d-4c41d2772eb8" width="400">


**Types of changes:**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.