### PR TITLE
[Enhancement]: Hover transitions added on Navbar Icons

### DIFF
--- a/client/src/Components/Navbar.js
+++ b/client/src/Components/Navbar.js
@@ -4,9 +4,26 @@ import SearchBar from './SearchBar';
 import { Link } from 'react-router-dom';
 function Navbar() {
     const [IsMobileView,setIsMobileView]=useState(false);
+    const [hoveredIcon, setHoveredIcon] = useState(null);
+
     const toggleMobileMenu=()=>{
         setIsMobileView(!IsMobileView);
     }
+
+    const handleMouseEnter = (icon) => {
+      setHoveredIcon(icon);
+    };
+  
+    const handleMouseLeave = () => {
+      setHoveredIcon(null);
+    };
+  
+    const naviconStyle = (icon) => ({
+      fill: hoveredIcon === icon ? '#8BBCF3' : 'none',
+      transform: hoveredIcon === icon ? 'scale(1.07)' : 'scale(1)',
+      transition: 'transform 0.2s, fill 0.2s'
+    });
+
   return (
     <div>
      <nav className="bg-darkblue p-3 fixed w-full top-0 z-50 shadow-sm">
@@ -30,23 +47,24 @@ function Navbar() {
     </div>
     <SearchBar/>
     <div className='m-5 flex gap-4' >
-      <span className='cursor-pointer'>
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="#fff" className="w-6 h-6 ">
-  <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 10.5V6a3.75 3.75 0 1 0-7.5 0v4.5m11.356-1.993 1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 0 1-1.12-1.243l1.264-12A1.125 1.125 0 0 1 5.513 7.5h12.974c.576 0 1.059.435 1.119 1.007ZM8.625 10.5a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm7.5 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
-</svg>
-</span>
-<span  className='cursor-pointer'>
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="#fff" className="w-6 h-6">
-  <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
-</svg>
-</span>
-<span  className='cursor-pointer'>
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="#fff" className="w-6 h-6">
-  <path strokeLinecap="round" strokeLinejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
-</svg>
-</span>
-    
-</div>
+      <span className="cursor-pointer" onMouseEnter={() => handleMouseEnter('icon1')} onMouseLeave={handleMouseLeave} style={naviconStyle('icon1')}>
+        <svg xmlns="http://www.w3.org/2000/svg" fill={hoveredIcon === 'icon1' ? '#fff' : 'none'} viewBox="0 0 24 24" strokeWidth={1.5} stroke="#fff" className="w-6 h-6 navicon">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 10.5V6a3.75 3.75 0 1 0-7.5 0v4.5m11.356-1.993 1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 0 1-1.12-1.243l1.264-12A1.125 1.125 0 0 1 5.513 7.5h12.974c.576 0 1.059.435 1.119 1.007ZM8.625 10.5a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm7.5 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
+        </svg>
+      </span>
+      
+      <span className="cursor-pointer" onMouseEnter={() => handleMouseEnter('icon2')} onMouseLeave={handleMouseLeave} style={naviconStyle('icon2')}>
+        <svg xmlns="http://www.w3.org/2000/svg" fill={hoveredIcon === 'icon2' ? '#fff' : 'none'} viewBox="0 0 24 24" strokeWidth={1.5} stroke="#fff" className="w-6 h-6 navicon">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+        </svg>
+      </span>
+
+      <span className="cursor-pointer" onMouseEnter={() => handleMouseEnter('icon3')} onMouseLeave={handleMouseLeave} style={naviconStyle('icon3')}>
+        <svg xmlns="http://www.w3.org/2000/svg" fill={hoveredIcon === 'icon3' ? '#fff' : 'none'} viewBox="0 0 24 24" strokeWidth={1.5} stroke="#fff" className="w-6 h-6 navicon">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
+        </svg>
+      </span>
+    </div>
  
     <div className="md:hidden ">
      <div className='flex justify-start gap-4'>


### PR DESCRIPTION
Navbar icons now scale a bit and transition to solid icons on hover.

![image](https://github.com/Niharika0104/TrendTrove/assets/117746995/4c5fc803-0263-4d87-a611-29b909ce0d1d)


Fixed #25 